### PR TITLE
Allow having Injectors per Verticle or one Injector for all Verticles

### DIFF
--- a/vertx-guice/src/main/java/com/englishtown/vertx/guice/InjectorBuilder.java
+++ b/vertx-guice/src/main/java/com/englishtown/vertx/guice/InjectorBuilder.java
@@ -1,0 +1,20 @@
+package com.englishtown.vertx.guice;
+
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+import java.util.List;
+
+/**
+ * Created by jensklingsporn on 19.10.15.
+ */
+public interface InjectorBuilder {
+
+    /**
+     *
+     * @param modules the modules to create the Injector with
+     * @param realVerticleName the name of the real verticle to load
+     * @return the Injector
+     */
+    Injector create(List<Module> modules, String realVerticleName);
+}

--- a/vertx-guice/src/main/java/com/englishtown/vertx/guice/impl/SingletonInjector.java
+++ b/vertx-guice/src/main/java/com/englishtown/vertx/guice/impl/SingletonInjector.java
@@ -1,0 +1,28 @@
+package com.englishtown.vertx.guice.impl;
+
+import com.englishtown.vertx.guice.InjectorBuilder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+import java.util.List;
+
+/**
+ * Created by jensklingsporn on 20.10.15.
+ */
+public class SingletonInjector implements InjectorBuilder {
+
+    private static Injector injector;
+
+    @Override
+    public Injector create(List<Module> modules, String realVerticleName) {
+        if(injector == null){
+            synchronized (getClass()){
+                if(injector == null){
+                    injector = Guice.createInjector(modules);
+                }
+            }
+        }
+        return injector;
+    }
+}

--- a/vertx-guice/src/main/java/com/englishtown/vertx/guice/impl/VerticleInjector.java
+++ b/vertx-guice/src/main/java/com/englishtown/vertx/guice/impl/VerticleInjector.java
@@ -1,0 +1,19 @@
+package com.englishtown.vertx.guice.impl;
+
+import com.englishtown.vertx.guice.InjectorBuilder;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+
+import java.util.List;
+
+/**
+ * Created by jensklingsporn on 20.10.15.
+ */
+public class VerticleInjector implements InjectorBuilder {
+
+    @Override
+    public Injector create(List<Module> modules, String realVerticleName) {
+        return Guice.createInjector(modules);
+    }
+}

--- a/vertx-guice/src/test/java/com/englishtown/vertx/guice/integration/CustomSingletonBinder.java
+++ b/vertx-guice/src/test/java/com/englishtown/vertx/guice/integration/CustomSingletonBinder.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.guice.integration;
+
+import com.englishtown.vertx.guice.DefaultMyDependency;
+import com.englishtown.vertx.guice.MyDependency;
+import com.google.inject.AbstractModule;
+
+/**
+ * Custom Guice binder
+ */
+public class CustomSingletonBinder extends AbstractModule {
+    @Override
+    protected void configure() {
+        bind(MyDependency.class).to(DefaultMyDependency.class).asEagerSingleton();
+    }
+}

--- a/vertx-guice/src/test/java/com/englishtown/vertx/guice/integration/DependencyInjectionVerticle3.java
+++ b/vertx-guice/src/test/java/com/englishtown/vertx/guice/integration/DependencyInjectionVerticle3.java
@@ -1,0 +1,27 @@
+package com.englishtown.vertx.guice.integration;
+
+import com.englishtown.vertx.guice.MyDependency;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.impl.ConcurrentHashSet;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Verticle with dependencies injected
+ */
+public class DependencyInjectionVerticle3 extends AbstractVerticle {
+
+    public static Set<MyDependency> dependencies = new ConcurrentHashSet<>();
+    private final MyDependency myDependency;
+
+    @Inject
+    public DependencyInjectionVerticle3(MyDependency myDependency) {
+        this.myDependency = myDependency;
+        assertNotNull(myDependency);
+        dependencies.add(myDependency);
+    }
+
+}


### PR DESCRIPTION
Hi, I'm following up on the discussion created at https://groups.google.com/forum/?fromgroups=#!topic/vertx/p-ZcfEy6Sp0
Currently, when deploying more than one Verticle, an Injector is created for each Verticle. That means that singletons are Verticle-scoped. I created an option to have one global Injector, in case you have Threadsafe-Singleton-Objects which can be shared across Verticles (e.g. Connection Pools).
I provided also an integration test.