### PR TITLE
Add the possibility to inject verticle's configuration

### DIFF
--- a/vertx-guice/src/main/java/com/englishtown/vertx/guice/GuiceVerticleLoader.java
+++ b/vertx-guice/src/main/java/com/englishtown/vertx/guice/GuiceVerticleLoader.java
@@ -50,6 +50,7 @@ public class GuiceVerticleLoader extends AbstractVerticle {
     private Verticle realVerticle;
 
     public static final String CONFIG_BOOTSTRAP_BINDER_NAME = "guice_binder";
+    public static final String GUICE_CONFIG = "guice_config";
     public static final String BOOTSTRAP_BINDER_NAME = "com.englishtown.vertx.guice.BootstrapBinder";
 
     public GuiceVerticleLoader(String verticleName, ClassLoader classLoader) {
@@ -149,7 +150,13 @@ public class GuiceVerticleLoader extends AbstractVerticle {
 
         // Add vert.x binder
         bootstraps.add(new GuiceVertxBinder(vertx));
-
+        
+        // Add vert.x verticle configuration binder
+        JsonObject guiceConfig = context.config().getJsonObject(GUICE_CONFIG);
+        if(guiceConfig != null) {
+            bootstraps.add(new GuiceVertxConfigBinder(context.config().getJsonObject(GUICE_CONFIG)));
+        }
+        
         // Each verticle factory will have it's own injector instance
         Injector injector = Guice.createInjector(bootstraps);
         return (Verticle) injector.getInstance(clazz);

--- a/vertx-guice/src/main/java/com/englishtown/vertx/guice/GuiceVertxConfigBinder.java
+++ b/vertx-guice/src/main/java/com/englishtown/vertx/guice/GuiceVertxConfigBinder.java
@@ -1,0 +1,30 @@
+package com.englishtown.vertx.guice;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+
+import io.vertx.core.json.JsonObject;
+
+public class GuiceVertxConfigBinder extends AbstractModule {
+    private static final String ROOT_PATH = "config";
+    
+    private final JsonObject config;
+    
+    public GuiceVertxConfigBinder(JsonObject config) {
+        this.config = config;
+    }
+    
+    private void bind(JsonObject config, String path) {
+        bind(JsonObject.class).annotatedWith(Names.named(path)).toInstance(config);
+        
+        config
+            .stream()
+            .filter(entry -> entry.getValue() instanceof JsonObject)
+            .forEach(entry -> bind((JsonObject)entry.getValue(), String.format("%s.%s", path, entry.getKey())));
+    }
+    
+    @Override
+    protected void configure() {
+        bind(config, ROOT_PATH);
+    }
+}


### PR DESCRIPTION
Had a project in hands where I needed for the injected instances to have access to the verticle's config.

I think this feature might be usefull for more people and worth of adding to the vertx-guice. :)

__Example:__

    vertx.deployVerticle(GuiceVerticleFactory.PREFIX + ":" +  "ExampleVerticle",
        new DeploymentOptions().setConfig(new JsonObject().put(GuiceVerticleFactory.GUICE_CONFIG, new JsonObject().put("api", new JsonObject().put("host", "localhost").put("port", 81)))),
        someHandler);

Injecting a configuration to an instance can be done using the Named annotation containing the "path" to the needed configuration, in the SomeClient class below config will contain a JsonObject with "{ host : "localhost", port: 81}". If you need the whole configuration JsonObject  just use a Named annotation containing "config", in this case it will be "{ api: { host : "localhost", port: 81} }".

    public class SomeClient  {
        @Inject
        public SomeClient(Vertx vertx, @Named("config.api") JsonObject config) {
            //Some initialisation code
        }
    }

Injecting SomeClient into a Verticle

    public class ExampleVerticle extends AbstractVerticle {
        @Inject
        public ExampleVerticle(SomeClient client) {
        }
    }
