### PR TITLE
Only warn about no binding module being found if no parent injector is defined.

### DIFF
--- a/vertx-guice/src/main/java/com/englishtown/vertx/guice/GuiceVerticleLoader.java
+++ b/vertx-guice/src/main/java/com/englishtown/vertx/guice/GuiceVerticleLoader.java
@@ -156,8 +156,10 @@ public class GuiceVerticleLoader extends AbstractVerticle {
                             + " does not implement Module.");
                 }
             } catch (ClassNotFoundException e) {
-                logger.error("Guice bootstrap binder class " + bootstrapName
-                        + " was not found.  Are you missing injection bindings?");
+                if (parent == null) {
+                    logger.warn("Guice bootstrap binder class " + bootstrapName
+                            + " was not found.  Are you missing injection bindings?");
+                }
             }
         }
 

--- a/vertx-guice/src/test/java/com/englishtown/vertx/guice/GuiceVerticleLoaderTest.java
+++ b/vertx-guice/src/test/java/com/englishtown/vertx/guice/GuiceVerticleLoaderTest.java
@@ -25,7 +25,9 @@ package com.englishtown.vertx.guice;
 
 import com.englishtown.vertx.guice.integration.CustomBinder;
 import com.englishtown.vertx.guice.integration.DependencyInjectionVerticle;
+import com.englishtown.vertx.guice.integration.DummyVerticle;
 import com.google.common.collect.Lists;
+import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import io.vertx.core.Context;
@@ -165,16 +167,30 @@ public class GuiceVerticleLoaderTest {
 
     @Test
     public void testStart_Class_Not_Found_Binder() throws Exception {
+        parent = null;
+        String binder = "com.englishtown.INVALID_BINDER";
+        config.put("guice_binder", binder);
 
+        String main = DummyVerticle.class.getName();
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        GuiceVerticleLoader loader = new GuiceVerticleLoader(main, cl, parent);
+        loader.init(vertx, context);
+        loader.start(future);
+        loader.stop(future);
+
+        verify(logger).warn(eq("Guice bootstrap binder class " + binder + " was not found.  Are you missing injection bindings?"));
+    }
+
+    @Test
+    public void testStart_Class_Not_Found_Binder_With_Parent() throws Exception {
         String binder = "com.englishtown.INVALID_BINDER";
         config.put("guice_binder", binder);
 
         String main = DependencyInjectionVerticle.class.getName();
         doTest(main);
 
-        verify(logger).error(eq("Guice bootstrap binder class " + binder + " was not found.  Are you missing injection bindings?"));
+        verifyZeroInteractions(logger);
         assertEquals(1, getModules().size());
-
     }
 
 }

--- a/vertx-guice/src/test/java/com/englishtown/vertx/guice/integration/DummyVerticle.java
+++ b/vertx-guice/src/test/java/com/englishtown/vertx/guice/integration/DummyVerticle.java
@@ -1,0 +1,17 @@
+/*
+ * This is the confidential unpublished intellectual property of EMC Corporation,
+ * and includes without limitation exclusive copyright and trade secret rights
+ * of EMC throughout the world.
+ */
+package com.englishtown.vertx.guice.integration;
+
+import io.vertx.core.AbstractVerticle;
+
+/**
+ * Verticle with no dependencies inejected.
+ */
+public class DummyVerticle extends AbstractVerticle {
+
+  public DummyVerticle() {
+  }
+}


### PR DESCRIPTION
Fixes #11.

Signed-off-by: Dan O'Reilly oreilldf@gmail.com
