### PR TITLE
Support Promise variants of start and stop methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <properties>
         <!--Dependency versions-->
         <guice.version>4.1.0</guice.version>
-        <vertx.version>3.3.0</vertx.version>
+        <vertx.version>3.8.3</vertx.version>
     </properties>
 
     <dependencies>

--- a/vertx-guice/src/main/java/com/englishtown/vertx/guice/GuiceVerticleLoader.java
+++ b/vertx-guice/src/main/java/com/englishtown/vertx/guice/GuiceVerticleLoader.java
@@ -87,9 +87,11 @@ public class GuiceVerticleLoader extends AbstractVerticle {
      * This is useful if your verticle deploys other verticles or modules and you don't want this verticle to
      * be considered started until the other modules and verticles have been started.
      *
+     * @deprecated Use {@link #start(Promise)} instead
      * @param startedResult When you are happy your verticle is started set the result
      * @throws Exception
      */
+    @Deprecated
     @Override
     public void start(Future<Void> startedResult) throws Exception {
         // Start the real verticle
@@ -97,16 +99,53 @@ public class GuiceVerticleLoader extends AbstractVerticle {
     }
 
     /**
+     * Start the verticle instance.
+     * <p>
+     * Vert.x calls this method when deploying the instance. You do not call it yourself.
+     * <p>
+     * A promise is passed into the method, and when deployment is complete the verticle should either call
+     * {@link io.vertx.core.Promise#complete} or {@link io.vertx.core.Promise#fail} the future.
+     *
+     * @param startPromise  the future
+     */
+    @Override
+    public void start(Promise<Void> startPromise) throws Exception {
+        // Start the real verticle
+        realVerticle.start(startPromise);
+    }
+
+    /**
      * Vert.x calls the stop method when the verticle is undeployed.
      * Put any cleanup code for your verticle in here
      *
+     * @deprecated Use {@link #stop(Promise)} instead
      * @throws Exception
      */
+    @Deprecated
     @Override
     public void stop(Future<Void> stopFuture) throws Exception {
         // Stop the real verticle
         if (realVerticle != null) {
             realVerticle.stop(stopFuture);
+            realVerticle = null;
+        }
+    }
+
+    /**
+     * Stop the verticle instance.
+     * <p>
+     * Vert.x calls this method when un-deploying the instance. You do not call it yourself.
+     * <p>
+     * A promise is passed into the method, and when un-deployment is complete the verticle should either call
+     * {@link io.vertx.core.Promise#complete} or {@link io.vertx.core.Promise#fail} the future.
+     *
+     * @param stopPromise  the future
+     */
+    @Override
+    public void stop(Promise<Void> stopPromise) throws Exception {
+        // Stop the real verticle
+        if (realVerticle != null) {
+            realVerticle.stop(stopPromise);
             realVerticle = null;
         }
     }

--- a/vertx-guice/src/test/java/com/englishtown/vertx/guice/integration/DependencyInjectionVerticle3.java
+++ b/vertx-guice/src/test/java/com/englishtown/vertx/guice/integration/DependencyInjectionVerticle3.java
@@ -1,0 +1,30 @@
+package com.englishtown.vertx.guice.integration;
+
+import com.englishtown.vertx.guice.MyDependency;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+
+import javax.inject.Inject;
+
+import static org.junit.Assert.assertNotNull;
+
+public class DependencyInjectionVerticle3 extends AbstractVerticle {
+
+    public static final String EB_ADDRESS = "et.address";
+    private final MyDependency myDependency;
+
+    @Inject
+    public DependencyInjectionVerticle3(MyDependency myDependency) {
+        this.myDependency = myDependency;
+        assertNotNull(myDependency);
+    }
+
+    @Override
+    public void start(Promise<Void> startPromise) throws Exception {
+        vertx.eventBus()
+                .<Void>consumer(EB_ADDRESS)
+                .handler(msg -> msg.reply(myDependency.getClass().getName()));
+
+        startPromise.complete();
+    }
+}


### PR DESCRIPTION
When creating a verticle that overrides the `Verticle#start(Promise<Void)` method, this module doesn't work correctly and fails to call start.

This is because `GuiceVerticleLoader` has no implementation of the promise method, which means execution falls to the default method in the `Verticle` interface. This eventually leads to the `GuiceVerticleLoader` attempting to call the real verticle's `#start(Future<Void>` method, rather than the Promise one.

So added the `start(Promise<Void>)` implementation to `GuiceVerticleLoader` and created a new test for it.